### PR TITLE
Add pointers to the held-out test set.

### DIFF
--- a/challenges/2019/tasks/guest_ava.html
+++ b/challenges/2019/tasks/guest_ava.html
@@ -233,9 +233,17 @@
         <div class="col-md-12 col-sm-12">
             <h3 class="section-title">Dataset</h3>
             <p>
-              The <a href="https://research.google.com/ava/download.html#ava_active_speaker_download" target="_blank">AVA-ActiveSpeaker dataset</a> will be used for this task. The AVA-ActiveSpeaker dataset associates speaking activity with a visible face on the AVA v1.0 videos. It contains 3.65 million frames, in 15-minute continuous video segments. It contains 120 videos for training, and 33 videos for validation. In addition, we will provide 131 videos for test. More information
-              about how to download the AVA dataset is
-              available <a href="https://github.com/cvdfoundation/ava-dataset" target="_blank">here</a>. The list of test videos will be available on the <a href="http://research.google.com/ava/download.html#ava_active_speaker_download" target="_blank">AVA website</a>, along with details of which timestamps will be used for testing.
+              The <a href="https://research.google.com/ava/download.html#ava_active_speaker_download" target="_blank">AVA-ActiveSpeaker dataset</a> will be used for this task. The AVA-ActiveSpeaker dataset associates speaking activity with a visible face on the AVA v1.0 videos. It contains 3.65 million frames, in 15-minute continuous video segments. It contains 120 videos for training, and 33 videos for validation. 
+            </p>
+            <p>
+              The held-out test set for the challenge, containing a total of 2,053,509 frames across all the test videos, is
+              now available at the <a href="https://research.google.com/ava/download.html#ava_active_speaker_download" target="_blank">Active Speaker Download page</a>. 
+              The true label for these entries is <b>not</b> provided; instead the label column always contains SPEAKING_AUDIBLE.
+            </p>
+            <p>
+              More information about how to download the AVA dataset is
+              available <a href="https://github.com/cvdfoundation/ava-dataset" target="_blank">here</a>, and information
+              about how to submit model predictions to the evaluation server are provided in the <b>Submission Format</b> section below.
             </p>
         </div>
       </div>
@@ -272,6 +280,10 @@
       <div class="row">
         <div class="col-md-12 col-sm-12">
           <h3 class="section-title">Submission Format</h3>
+          <p>
+            Submissions to the evaluation server will consist of a <b>single CSV file</b>, containing model predictions for
+            each entry in each video in the held out test set, and must therefore contain a total of 2,053,509 lines.
+          </p>
           <p>
             When submitting your results for this task, please use the same CSV format used for the ground truth AVA-ActiveSpeaker train/val files, with the addition of a score column for each box-label.
           </p>


### PR DESCRIPTION
1. Add links to the now-available held out test set.
2. Updates the submission format section to indicate that the evaluation server requires a single predictions file as input.